### PR TITLE
Future tasks/ Today's tasks

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -41,6 +41,11 @@ class TodosController < ApplicationController
     render :json => due_later
   end
 
+  def all_today
+    todays_tasks = Todo.where(:due_date => Date.today)
+    render :json => todays_tasks
+  end
+
   private
 
   def todo_params

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -36,10 +36,15 @@ class TodosController < ApplicationController
     render :json => due_today
   end
 
+  def future
+    due_later = Todo.where(:due_date.gt => Date.today, completed: false)
+    render :json => due_later
+  end
+
   private
 
   def todo_params
-    params.permit(:title, :completed, :order)
+    params.permit(:title, :completed, :order, :due_date)
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
 
   resources :today, to: 'todos#today', only: [:index]
   resources :future, to: 'todos#future', only: [:index]
+  resources :all_today, to: 'todos#all_today', only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   root 'todos#index'
 
   resources :today, to: 'todos#today', only: [:index]
+  resources :future, to: 'todos#future', only: [:index]
 end

--- a/spec/requests/todo_request_spec.rb
+++ b/spec/requests/todo_request_spec.rb
@@ -102,5 +102,20 @@ describe Todo do
   
       expect(data.count).to eq(2)
     end
+
+    it "can return all complete and incomplete tasks for today" do
+      tomorrow = Date.today + 1
+  
+      post '/todos', params: { :title => "Example 2", :order => 2, :completed => true}
+      post '/todos', params: { :title => "Example 3", :order => 3, :due_date => tomorrow }
+  
+      get "/all_today"
+  
+      data = JSON.parse(response.body, symbolize_names: true)
+  
+      expect(data.count).to eq(2)
+      expect(data.first[:title]).to eq("Example 1")
+      expect(data[1][:title]).to eq("Example 2")
+    end
   end
 end

--- a/spec/requests/todo_request_spec.rb
+++ b/spec/requests/todo_request_spec.rb
@@ -89,5 +89,18 @@ describe Todo do
       expect(data[0][:title]).to eq("Example 1")
       expect(data[1][:title]).to eq("Example 2")
     end
+
+    it "can return all incomplete tasks due in the future" do
+      tomorrow = Date.today + 1
+  
+      post '/todos', params: { :title => "Example 2", :order => 2, :due_date => tomorrow }
+      post '/todos', params: { :title => "Example 3", :order => 3, :due_date => tomorrow }
+  
+      get "/future"
+  
+      data = JSON.parse(response.body, symbolize_names: true)
+  
+      expect(data.count).to eq(2)
+    end
   end
 end

--- a/spec/requests/todo_request_spec.rb
+++ b/spec/requests/todo_request_spec.rb
@@ -58,12 +58,15 @@ describe Todo do
     end
 
     it "can delete a single task" do
-      expect(Todo.count).to eq(1)
+      task_params = { :title => "Example 2", :order => 2 }
+      post '/todos', {params: task_params}
+
+      expect(Todo.count).to eq(2)
 
       task = Todo.first
 
       delete "/todos/#{task.id}"
-      expect(Todo.count).to eq(0)
+      expect(Todo.count).to eq(1)
     end
 
     it "can delete all tasks" do
@@ -87,7 +90,11 @@ describe Todo do
   
       expect(data.count).to eq(2)
       expect(data[0][:title]).to eq("Example 1")
+      expect(data[0][:completed]).to be false
+      expect(data[0][:due_date]).to eq(Date.today.to_s)
       expect(data[1][:title]).to eq("Example 2")
+      expect(data[1][:completed]).to be false
+      expect(data[1][:due_date]).to eq(Date.today.to_s)
     end
 
     it "can return all incomplete tasks due in the future" do
@@ -101,6 +108,12 @@ describe Todo do
       data = JSON.parse(response.body, symbolize_names: true)
   
       expect(data.count).to eq(2)
+      expect(data[0][:title]).to eq('Example 2')
+      expect(data[0][:completed]).to be false
+      expect(data[0][:due_date]).to eq(tomorrow.to_s)
+      expect(data[1][:title]).to eq('Example 3')
+      expect(data[1][:completed]).to be false
+      expect(data[1][:due_date]).to eq(tomorrow.to_s)
     end
 
     it "can return all complete and incomplete tasks for today" do

--- a/spec/requests/todo_request_spec.rb
+++ b/spec/requests/todo_request_spec.rb
@@ -1,134 +1,152 @@
 require "rails_helper"
 
 describe Todo do
-  describe "(happy path)" do
-    before do
-      Todo.destroy_all
-      
-      task_params = { :title => "Example 1", :order => 1 }
-      post '/todos', {params: task_params}
-    end
+  before do
+    Todo.destroy_all
+    
+    task_params = { :title => "Example 1", :order => 1 }
+    post '/todos', {params: task_params}
+  end
 
-    it "can create a new task" do
-      data = JSON.parse(response.body, symbolize_names: true)
-      expect(data[:title]).to eq("Example 1")
-      expect(data[:order]).to eq(1)
-      expect(data[:created_at])
-      expect(data[:completed]).to eq(false)
-    end
+  it "can create a new task" do
+    data = JSON.parse(response.body, symbolize_names: true)
+    expect(data[:title]).to eq("Example 1")
+    expect(data[:order]).to eq(1)
+    expect(data[:created_at])
+    expect(data[:completed]).to eq(false)
+  end
 
-    it "can return a single task" do
-      task = Todo.first
-  
-      get "/todos/#{task.id}"
-  
-      task_data = JSON.parse(response.body, symbolize_names: true)
-  
-      expect(task_data[:title]).to eq("Example 1")
-      expect(task_data[:completed]).to be false
-      expect(task_data[:order]).to eq(1)
-      expect(task_data[:url]).to be_a(String)
-    end
+  it "can return a single task" do
+    task = Todo.first
 
-    it "can update a task" do
-      task = Todo.first
-      expect(task.completed).to eq(false)
-  
-      patch "/todos/#{task.id}", params: { completed: true }
-  
-      task.reload
-  
-      expect(task.completed).to eq(true)
-    end
+    get "/todos/#{task.id}"
 
-    it "can show all tasks" do
-      task_params = { :title => "Example 2", :order => 2 }
-      
-      post '/todos', {params: task_params}
-  
-      expect(Todo.count).to eq(2)
-  
-      get '/todos'
-  
-      tasks_data = JSON.parse(response.body, symbolize_names: true)
-  
-      expect(tasks_data.count).to eq(2)
-      expect(tasks_data[0][:title]).to eq("Example 1")
-      expect(tasks_data[1][:title]).to eq("Example 2")
-    end
+    task_data = JSON.parse(response.body, symbolize_names: true)
 
-    it "can delete a single task" do
-      task_params = { :title => "Example 2", :order => 2 }
-      post '/todos', {params: task_params}
+    expect(task_data[:title]).to eq("Example 1")
+    expect(task_data[:completed]).to be false
+    expect(task_data[:order]).to eq(1)
+    expect(task_data[:url]).to be_a(String)
+  end
 
-      expect(Todo.count).to eq(2)
+  it "can update a task" do
+    task = Todo.first
+    expect(task.completed).to eq(false)
 
-      task = Todo.first
+    patch "/todos/#{task.id}", params: { completed: true }
 
-      delete "/todos/#{task.id}"
-      expect(Todo.count).to eq(1)
-    end
+    task.reload
 
-    it "can delete all tasks" do
-      task_params = { :title => "Example 2", :order => 2 }
-      post '/todos', {params: task_params}
-  
-      expect(Todo.count).to eq(2)
-  
-      delete '/todos'
-  
-      expect(Todo.count).to eq(0)
-    end
+    expect(task.completed).to eq(true)
+  end
 
-    it "can return all incomplete tasks due today" do
-      post '/todos', params: { :title => "Example 2", :order => 2 }
-      post '/todos', params: { :title => "Example 3", :order => 3, :completed => true }
-  
-      get "/today"
-  
-      data = JSON.parse(response.body, symbolize_names: true)
-  
-      expect(data.count).to eq(2)
-      expect(data[0][:title]).to eq("Example 1")
-      expect(data[0][:completed]).to be false
-      expect(data[0][:due_date]).to eq(Date.today.to_s)
-      expect(data[1][:title]).to eq("Example 2")
-      expect(data[1][:completed]).to be false
-      expect(data[1][:due_date]).to eq(Date.today.to_s)
-    end
+  it "can show all tasks" do
+    task_params = { :title => "Example 2", :order => 2 }
+    
+    post '/todos', {params: task_params}
 
-    it "can return all incomplete tasks due in the future" do
-      tomorrow = Date.today + 1
-  
-      post '/todos', params: { :title => "Example 2", :order => 2, :due_date => tomorrow }
-      post '/todos', params: { :title => "Example 3", :order => 3, :due_date => tomorrow }
-  
-      get "/future"
-  
-      data = JSON.parse(response.body, symbolize_names: true)
-  
-      expect(data.count).to eq(2)
-      expect(data[0][:title]).to eq('Example 2')
-      expect(data[0][:completed]).to be false
-      expect(data[0][:due_date]).to eq(tomorrow.to_s)
-      expect(data[1][:title]).to eq('Example 3')
-      expect(data[1][:completed]).to be false
-      expect(data[1][:due_date]).to eq(tomorrow.to_s)
-    end
+    expect(Todo.count).to eq(2)
 
-    it "can return all complete and incomplete tasks for today" do
-      tomorrow = Date.today + 1
-  
-      post '/todos', params: { :title => "Example 2", :order => 2, :completed => true}
-      post '/todos', params: { :title => "Example 3", :order => 3, :due_date => tomorrow }
-  
-      get "/all_today"
-  
-      data = JSON.parse(response.body, symbolize_names: true)
-  
-      expect(data.count).to eq(2)
-      expect(data.first[:title]).to eq("Example 1")
-      expect(data[1][:title]).to eq("Example 2")
-    end
+    get '/todos'
+
+    tasks_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(tasks_data.count).to eq(2)
+    expect(tasks_data[0][:title]).to eq("Example 1")
+    expect(tasks_data[1][:title]).to eq("Example 2")
+  end
+
+  it "can delete a single task" do
+    task_params = { :title => "Example 2", :order => 2 }
+    post '/todos', {params: task_params}
+
+    expect(Todo.count).to eq(2)
+
+    task = Todo.first
+
+    delete "/todos/#{task.id}"
+    expect(Todo.count).to eq(1)
+  end
+
+  it "can delete all tasks" do
+    task_params = { :title => "Example 2", :order => 2 }
+    post '/todos', {params: task_params}
+
+    expect(Todo.count).to eq(2)
+
+    delete '/todos'
+
+    expect(Todo.count).to eq(0)
+  end
+
+  it "can return all incomplete tasks due today" do
+    post '/todos', params: { :title => "Example 2", :order => 2 }
+    post '/todos', params: { :title => "Example 3", :order => 3, :completed => true }
+
+    get "/today"
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data.count).to eq(2)
+    expect(data[0][:title]).to eq("Example 1")
+    expect(data[0][:completed]).to be false
+    expect(data[0][:due_date]).to eq(Date.today.to_s)
+    expect(data[1][:title]).to eq("Example 2")
+    expect(data[1][:completed]).to be false
+    expect(data[1][:due_date]).to eq(Date.today.to_s)
+  end
+
+  it "can return all incomplete tasks due in the future" do
+    tomorrow = Date.today + 1
+
+    post '/todos', params: { :title => "Example 2", :order => 2, :due_date => tomorrow }
+    post '/todos', params: { :title => "Example 3", :order => 3, :due_date => tomorrow }
+
+    get "/future"
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data.count).to eq(2)
+    expect(data[0][:title]).to eq('Example 2')
+    expect(data[0][:completed]).to be false
+    expect(data[0][:due_date]).to eq(tomorrow.to_s)
+    expect(data[1][:title]).to eq('Example 3')
+    expect(data[1][:completed]).to be false
+    expect(data[1][:due_date]).to eq(tomorrow.to_s)
+  end
+
+  it "can return all complete and incomplete tasks for today" do
+    tomorrow = Date.today + 1
+
+    post '/todos', params: { :title => "Example 2", :order => 2, :completed => true}
+    post '/todos', params: { :title => "Example 3", :order => 3, :due_date => tomorrow }
+
+    get "/all_today"
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data.count).to eq(2)
+    expect(data.first[:title]).to eq("Example 1")
+    expect(data[1][:title]).to eq("Example 2")
+  end
+
+  it "returns an empty array if there are no tasks to complete today" do
+    Todo.destroy_all
+    get "/today"
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data).to be_an(Array)
+    expect(data.count).to eq(0)
+  end
+
+  it "returns an empty array if there are no tasks to complete in the future" do
+    Todo.destroy_all
+    get "/future"
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data).to be_an(Array)
+    expect(data.count).to eq(0)
   end
 end


### PR DESCRIPTION
This Pull Request adds the following features:
- `future` endpoint: returns all incomplete tasks due after today
- `all_today` endpoint: returns all complete and incomplete tasks due today
- Reformat request spec tests to not be nested in extra describe block

- [x] All tests passing, coverage at 100%